### PR TITLE
fix: #78 Use musl-native precompiled gems to fix code_ownership 2.1.1 build failure on Alpine

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,6 +29,15 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+        exclude:
+          # code_ownership 2.1.1 (pinned by canvas-lms) publishes no
+          # aarch64-linux-musl gem, and this image does not build its Rust
+          # extension from source, so ARM64 Alpine is unsupported.
+          # 2.1.3+ publishes aarch64-linux-musl, so once canvas-lms bumps
+          # Gemfile.lock to code_ownership >= 2.1.3 this exclude can be removed.
+          # Use the Debian image for ARM64 until then.
+          - os: alpine
+            platform: linux/arm64
 
     steps:
       - name: Prepare

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -16,6 +16,10 @@ ARG CANVAS_HOME
 ENV RAILS_ENV=production
 ENV COMPILE_ASSETS_BRAND_CONFIGS=0
 ENV SASS_STYLE=compressed
+# Operate on the single (main) lockfile so canvas-lms's vendored bundler-multilock
+# plugin does not re-resolve the per-gem secondary lockfiles, which fails on gems
+# (e.g. nokogiri) that dropped the legacy `x86_64-linux` platform.
+ENV BUNDLE_LOCKFILE=Gemfile.lock
 
 COPY --link --from=node /usr/local/bin /usr/local/bin
 COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
@@ -23,8 +27,6 @@ COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN apk add --no-cache \
     alpine-sdk \
     bash \
-    cargo \
-    clang-dev \
     libidn-dev \
     libpq-dev \
     python3 \
@@ -48,29 +50,18 @@ WORKDIR ${CANVAS_HOME}
 RUN <<EOF
 corepack enable yarn
 
-# RubyGems 3.6.x CargoBuilder uses Open3.capture2e (merging stderr into stdout)
-# and parses the combined output with SafeYAML. This breaks when cargo emits
-# warnings (e.g. `.cargo/config` deprecation) that pollute the JSON output.
-# Backport the fix: switch to JSON.parse and strip non-JSON stderr preamble.
-# https://github.com/rubyatscale/code_ownership/issues/151
-# https://github.com/ruby/rubygems/pull/9373
-# TODO: Remove this workaround once Canvas LMS upgrades to Ruby 4.x
-#       (RubyGems 4.0.8+ includes the CargoBuilder fix).
-ruby -e '
-  path = File.join(RbConfig::CONFIG["rubylibdir"], "rubygems", "ext", "cargo_builder.rb")
-  code = File.read(path)
-  code.gsub!(
-    "metadata = Gem::SafeYAML.safe_load(output)",
-    "require \"json\"
-     output = output.sub(/\\A[^{]*/m, \"\")
-     metadata = JSON.parse(output)"
-  )
-  File.write(path, code)
-'
-
-# Build all native extensions from source to avoid precompiled binaries
-# linked against glibc, which cause `Error loading shared library` on musl.
-bundle config set force_ruby_platform true
+# canvas-lms parses its Gemfile through the vendored bundler-multilock plugin
+# and raises unless it is installed, so the plugin must be present before
+# `bundle lock` can read the Gemfile.
+bundle plugin install bundler-multilock
+# canvas-lms's Gemfile.lock lists `x86_64-linux`/`aarch64-linux` (glibc)
+# but no musl platform, so on Alpine (musl) Bundler would install those glibc gems,
+# whose native extensions cannot be dlopen'd on musl (`Error loading shared
+# library ld-linux-x86-64.so.2`).
+# Add the musl platforms so Bundler picks musl-native precompiled gems
+# where available (notably code_ownership's Rust extension, which this image
+# does not build from source) and builds the remaining gems from source.
+bundle lock --add-platform x86_64-linux-musl aarch64-linux-musl
 bundle install
 
 rails canvas:compile_assets
@@ -146,6 +137,11 @@ ARG RAILS_PORT=3000
 
 ENV BINDING=0.0.0.0
 ENV PORT=${RAILS_PORT}
+# Operate on the single (main) lockfile at runtime too; otherwise bundler-multilock
+# resolves every lockfile and `rails server` fails to boot on the test-group git
+# gem crystalball (not installed in production) with `crystalball.git is not yet
+# checked out`.
+ENV BUNDLE_LOCKFILE=Gemfile.lock
 
 RUN <<EOF
 apk add --no-cache \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -24,7 +24,6 @@ COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends \
-    cargo \
     libidn-dev \
     libxmlsec1-dev
 EOF
@@ -42,26 +41,6 @@ WORKDIR ${CANVAS_HOME}
 
 RUN <<EOF
 corepack enable yarn
-
-# RubyGems 3.6.x CargoBuilder uses Open3.capture2e (merging stderr into stdout)
-# and parses the combined output with SafeYAML. This breaks when cargo emits
-# warnings (e.g. `.cargo/config` deprecation) that pollute the JSON output.
-# Backport the fix: switch to JSON.parse and strip non-JSON stderr preamble.
-# https://github.com/rubyatscale/code_ownership/issues/151
-# https://github.com/ruby/rubygems/pull/9373
-# TODO: Remove this workaround once Canvas LMS upgrades to Ruby 4.x
-#       (RubyGems 4.0.8+ includes the CargoBuilder fix).
-ruby -e '
-  path = File.join(RbConfig::CONFIG["rubylibdir"], "rubygems", "ext", "cargo_builder.rb")
-  code = File.read(path)
-  code.gsub!(
-    "metadata = Gem::SafeYAML.safe_load(output)",
-    "require \"json\"
-     output = output.sub(/\\A[^{]*/m, \"\")
-     metadata = JSON.parse(output)"
-  )
-  File.write(path, code)
-'
 
 bundle install
 


### PR DESCRIPTION
Install `code_ownership` from its musl-native precompiled gem on Alpine instead
of building the Rust extension from source. After installing the vendored
bundler-multilock plugin, add the musl platforms with
`bundle lock --add-platform x86_64-linux-musl aarch64-linux-musl` and pin Bundler
to the main lockfile via `BUNDLE_LOCKFILE=Gemfile.lock` in both the builder and
final stages.

The CargoBuilder patch from #76 only repairs `cargo metadata` parsing; the
`code_ownership` 2.1.1 Rust extension (magnus/rb-sys) still fails to compile
against Ruby 3.4.9. Installing the precompiled gem makes that patch — and the
`cargo` / `clang-dev` toolchain — unnecessary, so they are removed from both
images.

`code_ownership` 2.1.1 publishes no `aarch64-linux-musl` binary, so ARM64 Alpine
is excluded from the build matrix; re-enable it once canvas-lms pins
`code_ownership >= 2.1.3` (the first version to publish that platform). AMD64
(Alpine/Debian) and ARM64 Debian are unaffected.

Verified: full builds of AMD64 Alpine, AMD64 Debian, and ARM64 Debian succeed,
and the resulting images load `code_ownership` at runtime.
